### PR TITLE
chore(tools): 移除 MPE 相关联动功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Talk is cheap, 请看: **[🎞️ Bilibili 视频演示](https://www.bilibili.co
 - `save_pipeline` - 保存 Pipeline JSON 到文件（支持新建和更新）
 - `load_pipeline` - 读取已有的 Pipeline 文件
 - `run_pipeline` - 运行 Pipeline 并返回执行结果（支持单/多文件、Custom action agent 自动启动）
-- `open_pipeline_in_browser` - 在浏览器中打开 Pipeline 可视化界面
 
 ### 🛑 Pipeline 终止
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -78,7 +78,6 @@ Talk is cheap, see: **[🎞️ Bilibili Video Demo](https://www.bilibili.com/vid
 - `save_pipeline` - Save Pipeline JSON to file (supports creating and updating)
 - `load_pipeline` - Load an existing Pipeline file
 - `run_pipeline` - Run Pipeline and return execution results (single/multi-file, auto-start Custom action agent)
-- `open_pipeline_in_browser` - Open Pipeline visualization in browser
 
 ### 🛑 Pipeline Termination
 

--- a/maa_mcp/pipeline_tools.py
+++ b/maa_mcp/pipeline_tools.py
@@ -8,7 +8,6 @@ Pipeline 生成支持模块
 """
 
 import json
-import webbrowser
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -16,7 +15,6 @@ from pathlib import Path
 from typing import Any, List, Optional, Union
 
 from loguru import logger
-from lzstring import LZString
 
 from maa_mcp.core import mcp, object_registry
 from maa_mcp.paths import ensure_within_pipelines_dir, get_data_dir
@@ -972,76 +970,6 @@ def run_pipeline(
     ).to_dict()
 
 
-"""
-MPE 相关配置
-"""
-
-# MPE 分享协议版本
-MPE_SHARE_VERSION = 1
-# URL 参数名
-MPE_SHARE_PARAM = "shared"
-# 默认 MPE 基准地址
-MPE_BASE_URL = "https://mpe.codax.site/stable"
-# URL 最大大小限制
-MPE_MAX_URL_SIZE = 60 * 1024  # 60KB
-
-
-def generate_share_link(pipeline_obj: dict) -> str:
-    # 生成分享链接
-    payload = {
-        "v": MPE_SHARE_VERSION,
-        "d": pipeline_obj,
-    }
-    json_string = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
-    lz = LZString()
-    compressed = lz.compressToEncodedURIComponent(json_string)
-    share_url = f"{MPE_BASE_URL}?{MPE_SHARE_PARAM}={compressed}"
-    return share_url
-
-
-@mcp.tool(
-    name="open_pipeline_in_browser",
-    description="""
-    通过浏览器打开 Pipeline JSON 可视化界面。
-
-    参数：
-    - pipeline_file_path: Pipeline JSON 文件的本地路径（字符串）
-
-    功能说明：
-    该工具会读取指定路径的 Pipeline JSON 文件，将数据压缩编码后生成一个分享链接，
-    并自动在系统默认浏览器中打开，方便用户可视化查看工作流结构。
-
-    注意：
-    - 此工具无返回值，仅执行打开浏览器的操作
-    - 仅在用户要求查看 Pipeline 可视化流程图时使用
-    - 传入的文件路径必须指向一个有效的本地 JSON 文件
-    - 如果生成的 URL 超过 60KB，将返回错误提示而不打开浏览器
-    """,
-)
-def open_pipeline_in_browser(pipeline_file_path: str) -> None:
-    # 读取文件内容
-    file_path = Path(pipeline_file_path)
-
-    if not file_path.exists():
-        raise FileNotFoundError(f"Pipeline 文件不存在: {pipeline_file_path}")
-    if not file_path.is_file():
-        raise ValueError(f"路径不是文件: {pipeline_file_path}")
-
-    with open(file_path, "r", encoding="utf-8") as f:
-        pipeline_obj = json.load(f)
-
-    # 生成分享链接
-    share_url = generate_share_link(pipeline_obj)
-
-    # 检查 URL 大小
-    url_size = len(share_url.encode("utf-8"))
-    if url_size > MPE_MAX_URL_SIZE:
-        size_kb = url_size / 1024
-        raise ValueError(
-            f"生成的分享链接过大（{size_kb:.2f} KB），请自行通过复制或文件的方式导入 Pipeline 至 MPE。"
-        )
-
-    webbrowser.open(share_url)
 
 
 @mcp.tool(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ dependencies = [
     "opencv-python>=4.0.0",
     "platformdirs>=4.0.0",
     "loguru>=0.7.0",
-    "lzstring>=1.0.4",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

- 移除 `open_pipeline_in_browser` tool 及其辅助函数 `generate_share_link`
- 移除 MPE 相关常量（`MPE_BASE_URL`、`MPE_SHARE_PARAM`、`MPE_MAX_URL_SIZE`、`MPE_SHARE_VERSION`）
- 移除 `lzstring` 依赖
- 更新 README 中英文文档

## Why

该工具存在 path traversal 安全风险（CWE-22），且 MPE 联动功能使用场景有限。直接移除比沙盒化更干净。

Resolve #32

## Summary by Sourcery

移除基于 MPE 的流水线可视化工具及其相关配置和依赖。

增强内容：
- 从流水线工具模块中移除 MPE 浏览器可视化工具及其相关常量。
- 由于不再生成 MPE 分享链接，移除运行时依赖 `lzstring`。

文档：
- 更新中文版和英文版 README 文件，移除对 MPE 浏览器可视化工具的相关文档说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the MPE-based pipeline visualization tool and its associated configuration and dependency.

Enhancements:
- Remove the MPE browser visualization tool and related constants from the pipeline tools module.
- Drop the lzstring runtime dependency now that MPE sharing links are no longer generated.

Documentation:
- Update Chinese and English README files to remove documentation of the MPE browser visualization tool.

</details>